### PR TITLE
fix: debug connect err

### DIFF
--- a/pool/connection.go
+++ b/pool/connection.go
@@ -202,6 +202,7 @@ func (ch *Connection) connect(ctx context.Context) error {
 			},
 		})
 	if err != nil {
+		ch.log.Error(err.Error())
 		// wrap the underlying amqp091 error
 		return fmt.Errorf("%v: %w", ErrConnectionFailed, err)
 	}


### PR DESCRIPTION
Use the connection logger to log the possible dial error here. Initial connect and retry logic is difficult to debug w/o any feedback.

Context:

I was using `amqpx.NewURL()` to set the `VirtualHost` for the connection string. The vhosts on servers I work with are all prefixed with `/`, so when this was stripped off and passed to dial I needed a debugger to inspect the underlying "no access to vhost" error.